### PR TITLE
Fixed Typo: 'regex_values' to 'regex_value'

### DIFF
--- a/threatelligence/etc/scanning_ip.ini
+++ b/threatelligence/etc/scanning_ip.ini
@@ -24,7 +24,7 @@ feed_name: Dragon_Research_Group_SSH
 temp_file: /tmp/drg_ssh_tmp
 final_file: /tmp/drg_ssh_sorted
 regex: \d{1,3}(?:\.\d{1,3}){3}
-regex_values: ipaddress
+regex_value: ipaddress
 severity: medium
 type: bruteforce
 
@@ -34,7 +34,7 @@ feed_name: Dragon_Research_Group_VNC
 temp_file: /tmp/drg_vnc_tmp
 final_file: /tmp/drg_vnc_sorted
 regex: \d{1,3}(?:\.\d{1,3}){3}
-regex_values: ipaddress
+regex_value: ipaddress
 severity: medium
 type: bruteforce
 
@@ -44,6 +44,6 @@ feed_name: OpenBlock_Bruteforce
 temp_file: /tmp/openblock_tmp
 final_file: /tmp/openblock_bf_sorted
 regex: \d{1,3}(?:\.\d{1,3}){3}
-regex_values: ipaddress
+regex_value: ipaddress
 severity: medium
 type: bruteforce


### PR DESCRIPTION
scanning_ip.ini had the field 'regex_values' instead of 'regex_value' for the last three entries. This was causing the script to throw an exception. Fixed and tested with success.
